### PR TITLE
Fix splitter expansion

### DIFF
--- a/data_processor/CSV_Processor_Rev5_Complete.py
+++ b/data_processor/CSV_Processor_Rev5_Complete.py
@@ -1665,7 +1665,8 @@ class CSVProcessorApp(ctk.CTk):
     def _create_splitter(self, parent, left_creator, right_creator, splitter_key, default_left_width):
         """Create a splitter with left and right panels."""
         splitter_frame = ctk.CTkFrame(parent)
-        splitter_frame.grid_columnconfigure(1, weight=1)
+        # Make the right panel expandable rather than the splitter handle
+        splitter_frame.grid_columnconfigure(2, weight=1)
         splitter_frame.grid_rowconfigure(0, weight=1)
         
         # Get saved width or use default


### PR DESCRIPTION
## Summary
- fix grid column weight so splitter handle doesn't expand

## Testing
- `python -m py_compile data_processor/CSV_Processor_Rev5_Complete.py`


------
https://chatgpt.com/codex/tasks/task_e_6887cb2a04908320b614cb91fc9876ab